### PR TITLE
Fix missing message in custom exception

### DIFF
--- a/FeignClientExceptionHandling/src/main/java/com/codemore/FeignClientExceptionHandling/exceptions/BillNotCreatedException.java
+++ b/FeignClientExceptionHandling/src/main/java/com/codemore/FeignClientExceptionHandling/exceptions/BillNotCreatedException.java
@@ -10,6 +10,7 @@ public class BillNotCreatedException extends RuntimeException {
     private ClaroErrorResponseDto claroErrorResponseDto;
 
     public BillNotCreatedException(ClaroErrorResponseDto claroErrorResponseDto) {
+        super(claroErrorResponseDto.getMessage());
         this.claroErrorResponseDto = claroErrorResponseDto;
     }
 }


### PR DESCRIPTION
## Summary
- ensure `BillNotCreatedException` propagates error message via `RuntimeException`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6842ef7a7b4c8330a60b50303c9a1dc6